### PR TITLE
Add CMake configuration file for easier build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+CMAKE_MINIMUM_REQUIRED ( VERSION 3.0 )
+
+CMAKE_POLICY ( VERSION 3.0 )
+
+PROJECT ( GPUMonitor )
+
+SET (CMAKE_CXX_STANDARD 11)
+
+ADD_EXECUTABLE ( gmonitor
+  src/console_writer.cpp
+  src/gpu.cpp
+  src/main.cpp
+  src/manager.cpp
+  src/stats_reader.cpp
+  )


### PR DESCRIPTION
Using CMake allows for easier and cleaner out of source directory builds.