### PR TITLE
Tidy up makefile and eliminate a warning

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -5,6 +5,11 @@ CXXFLAGS=-O2 -std=c++11
 all: gmonitor
 
 gmonitor: console_writer.o main.o gpu.o manager.o stats_reader.o
+	@echo 'Building target: $@'
+	@echo 'Invoking: Cross G++ Linker'
+	g++ console_writer.o main.o gpu.o manager.o stats_reader.o -o gmonitor
+	@echo 'Finished building target: $@'
+	@echo ' '
 
 console_writer.o: console_writer.cpp console_writer.h
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,24 +1,21 @@
-gmonitor: console_writer.o main.o gpu.o manager.o stats_reader.o constants.h utils.h
-	@echo 'Building target: $@'
-	@echo 'Invoking: Cross G++ Linker'
-	g++ console_writer.o main.o gpu.o manager.o stats_reader.o -o gmonitor
-	@echo 'Finished building target: $@'
-	@echo ' '
-	
-console_writer: console_writer.cpp console_writer.h
-	g++ -c console_writer.cpp
+CXXFLAGS=-O2 -std=c++11
 
-main: main.cpp
-	g++ -c main.cpp
+.PHONY: all
 
-gpu: gpu.cpp gpu.h
-	g++ -c gpu.cpp
+all: gmonitor
 
-manager: manager.cpp manager.h
-	g++ -c manager.cpp
+gmonitor: console_writer.o main.o gpu.o manager.o stats_reader.o
 
-stats_reader: stats_reader.cpp stats_reader.h
-	g++ -c stats_reader.cpp
-	
+console_writer.o: console_writer.cpp console_writer.h
+
+main.o: main.cpp constants.h utils.h
+
+gpu.o: gpu.cpp gpu.h
+
+manager.o: manager.cpp manager.h
+
+stats_reader.o: stats_reader.cpp stats_reader.h
+
+.PHONY: clean
 clean:
-	rm *.o gmonitor
+	rm -f *.o gmonitor


### PR DESCRIPTION
The makefile, as written, had some trailing tags in places that would have caused problems if the rules were ever invoked, but implicit rules were preventing the errors from being visible.  This PR removes the errors and specifies dependencies more clearly.

It also eliminates a warning involving the need for using the C++11 standard.